### PR TITLE
Missing dependencies for Ubuntu/debian in install.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ Run the following commands:
 
 ```bash
 sudo apt install make g++ git autoconf
-sudo apt install zlib1g-dev libpng-dev libxpm-dev libx11-dev libxft-dev libxinerama-dev libfontconfig1-dev x11proto-xext-dev libxrender-dev libxfixes-dev libcairo2-dev libpango1.0-dev
+sudo apt install zlib1g-dev libpng-dev libxpm-dev libx11-dev libxft-dev libxinerama-dev libfontconfig1-dev x11proto-xext-dev libxrender-dev libxfixes-dev libcairo2-dev libpango1.0-dev libwayland-dev libglew-dev libdecor-0-dev
 ```
 
 #### Fedora


### PR DESCRIPTION
On modern Debian derivatives (anything running Wayland), FLTK will fail to build using the previous instructions. This commit adds the missing dependencies.