### PR TITLE
Update FLTK to 1.4.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,15 +21,24 @@ jobs:
         with:
           path: lib/fltk
           repository: fltk/fltk
-          ref: release-1.4.4
+          ref: release-1.4.5
           fetch-depth: 1
 
       - name: Install FLTK
         working-directory: lib/fltk
         run: |
-          cmake -D CMAKE_INSTALL_PREFIX="$(realpath "$PWD/../..")" -D CMAKE_BUILD_TYPE=Release -D FLTK_GRAPHICS_CAIRO=1 -D FLTK_BACKEND_WAYLAND=0 -D FLTK_USE_SYSTEM_LIBPNG=0 -D FLTK_USE_SYSTEM_ZLIB=0 -D FLTK_BUILD_GL=0 -D FLTK_BUILD_TEST=0
-          make
-          make install
+          cmake -B build \
+            -D CMAKE_INSTALL_PREFIX="$(realpath "$PWD/../..")" \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D FLTK_ABI_VERSION=10405 \
+            -D FLTK_BUILD_GL=0 \
+            -D FLTK_BUILD_TEST=0 \
+            -D FLTK_GRAPHICS_CAIRO=1 \
+            -D FLTK_BACKEND_WAYLAND=0 \
+            -D FLTK_USE_SYSTEM_LIBPNG=0 \
+            -D FLTK_USE_SYSTEM_ZLIB=0
+          cmake --build build
+          cmake --install build
 
       - name: Build
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,14 +18,14 @@ If the pre-built release already works for you, you don't have to build it yours
 1. On GitHub, click the green "**Code**" button and click "**Download ZIP**". This will download **tilemap-studio-master.zip**.
 2. Unzip tilemap-studio-master.zip. This will create the **tilemap-studio-master** folder.
 3. Navigate to the tilemap-studio-master folder in Explorer.
-4. Download fltk-1.4.4-source.tar.bz2 or fltk-1.4.4-source.tar.gz from [**fltk.org**](https://www.fltk.org/software.php) to a new **tilemap-studio-master\lib** subfolder.
-5. Extract fltk-1.4.4-source.tar (you may need a program such as [7-Zip](https://www.7-zip.org/)). This will create the lib\\**fltk-1.4.4** folder.
-6. Open Visual Studio, select **Open a local folder**, and open the lib\fltk-1.4.4 folder. This will automatically generate the CMake project with a configuration named **x64-Debug** by default.
-7. From the Configuration dropdown, select **Manage Configurations...**, click the green plus sign to add a new configuration, and select **x86-Release** from the list. Set the **Configuration type** to **Release**, set the **Toolset** to **msvc_x86_x64**, and uncheck the **FLTK_GRAPHICS_GDIPLUS** option in the list of CMake variables.
+4. Download fltk-1.4.5-source.tar.bz2 or fltk-1.4.5-source.tar.gz from [**fltk.org**](https://www.fltk.org/software.php) to a new **tilemap-studio-master\lib** subfolder.
+5. Extract fltk-1.4.5-source.tar (you may need a program such as [7-Zip](https://www.7-zip.org/)). This will create the lib\\**fltk-1.4.5** folder.
+6. Open Visual Studio, select **Open a local folder**, and open the lib\fltk-1.4.5 folder. This will automatically generate the CMake project with a configuration named **x64-Debug** by default.
+7. From the Configuration dropdown, select **Manage Configurations...**, click the green plus sign to add a new configuration, and select **x86-Release** from the list. Set the **Configuration type** to **Release** and set the **Toolset** to **msvc_x86_x64**. In the list of CMake variables, uncheck the **FLTK_GRAPHICS_GDIPLUS** option and set the **FLTK_ABI_VERSION** option to **10405**.
 8. Set the active Configuration to **x86-Release**.
 9. In the **Solution Explorer**, switch to the **CMake Targets View**, right-click on **fltk_images**, and select **Build fltk_images**. This will also build the other required libraries: fltk, fltk_png, and fltk_z.
-10. Move all the .lib files from lib\fltk-1.4.4\out\build\x86-Release\lib\\\*.lib up to lib\\\*.lib.
-11. Copy the lib\fltk-1.4.4\\**FL** folder to a new include\\**FL** folder. Also copy lib\fltk-1.4.4\out\build\x86-Release\FL\fl_config.h into include\FL.
+10. Move all the .lib files from lib\fltk-1.4.5\out\build\x86-Release\lib\\\*.lib up to lib\\\*.lib.
+11. Copy the lib\fltk-1.4.5\\**FL** folder to a new include\\**FL** folder. Also copy lib\fltk-1.4.5\out\build\x86-Release\FL\fl_config.h into include\FL.
 12. Open ide\tilemap-studio.sln in Visual Studio 2019.
 13. If the Solution Configuration dropdown on the toolbar says Debug, set it to **Release**.
 14. Go to **Build → Build Solution** or press F7 to build the project. This will create bin\Release\\**tilemapstudio.exe**.
@@ -45,7 +45,7 @@ CMake (version 3.15 or later) is required for building FLTK 1.4.
 Run the following commands:
 
 ```bash
-sudo apt install make g++ git autoconf
+sudo apt install make g++ git autoconf cmake
 sudo apt install zlib1g-dev libpng-dev libxpm-dev libx11-dev libxft-dev libxinerama-dev libfontconfig1-dev x11proto-xext-dev libxrender-dev libxfixes-dev libcairo2-dev libpango1.0-dev
 ```
 
@@ -54,7 +54,7 @@ sudo apt install zlib1g-dev libpng-dev libxpm-dev libx11-dev libxft-dev libxiner
 Run the following commands:
 
 ```bash
-sudo dnf install make g++ git autoconf
+sudo dnf install make g++ git autoconf cmake
 sudo dnf install zlib-devel libpng-devel libXpm-devel libX11-devel libXft-devel libXinerama-devel fontconfig-devel libXext-devel libXrender-devel libXfixes-devel libcairo2-devel libpango1.0-devel
 ```
 
@@ -67,12 +67,21 @@ Run the following commands:
 git clone https://github.com/Rangi42/tilemap-studio.git
 cd tilemap-studio
 
-# Build FLTK 1.4.4
-git clone --branch release-1.4.4 --depth 1 https://github.com/fltk/fltk.git lib/fltk
+# Build FLTK 1.4.5
+git clone --branch release-1.4.5 --depth 1 https://github.com/fltk/fltk.git lib/fltk
 pushd lib/fltk
-cmake -D CMAKE_INSTALL_PREFIX="$(realpath "$PWD/../..")" -D CMAKE_BUILD_TYPE=Release -D FLTK_GRAPHICS_CAIRO=1 -D FLTK_BACKEND_WAYLAND=0 -D FLTK_USE_SYSTEM_LIBPNG=0 -D FLTK_USE_SYSTEM_ZLIB=0
-make
-make install
+cmake -B build \
+	-D CMAKE_INSTALL_PREFIX="$(realpath "$PWD/../..")" \
+	-D CMAKE_BUILD_TYPE=Release \
+	-D FLTK_ABI_VERSION=10405 \
+	-D FLTK_BUILD_GL=0 \
+	-D FLTK_BUILD_TEST=0 \
+	-D FLTK_GRAPHICS_CAIRO=1 \
+	-D FLTK_BACKEND_WAYLAND=0 \
+	-D FLTK_USE_SYSTEM_LIBPNG=0 \
+	-D FLTK_USE_SYSTEM_ZLIB=0
+cmake --build build
+cmake --install build
 popd
 
 # Build Tilemap Studio

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -98,4 +98,3 @@ std::string Preferences::get_string(const char *key) {
 void Preferences::set_string(const char *key, const std::string &value) {
 	_preferences->set(key, value.c_str());
 }
-

--- a/src/widgets.cpp
+++ b/src/widgets.cpp
@@ -340,8 +340,8 @@ int Default_Slider::handle(int event, int x, int y, int w, int h) {
 
 HTML_View::HTML_View(int x, int y, int w, int h, const char *l) : Fl_Help_View(x, y, w, h, l) {
 	box(OS_INPUT_THIN_DOWN_BOX);
-	// TODO: scrollbar_.slider(OS_MINI_BUTTON_UP_BOX);
-	// TODO: hscrollbar_.slider(OS_MINI_BUTTON_UP_BOX);
+	scrollbar()->slider(OS_MINI_BUTTON_UP_BOX);
+	hscrollbar()->slider(OS_MINI_BUTTON_UP_BOX);
 	textsize(16);
 }
 


### PR DESCRIPTION
1. Update FLTK to 1.4.5
2. Use out-of-tree cmake build for FLTK (will be required starting in FLTK 1.5, planned to be released later this year)
   - This refers to `cmake -B build`, `cmake --build build`, and `cmake --install build`
3. Set `FLTK_ABI_VERSION` to `10405` (doesn't enable anything really essential, but nice to have)
4. Update HTML_View scrollbar slider box type (possible as of FLTK 1.4.4)