### PR TITLE
Fix X11 build against FLTK 1.4.5 (explicit platform/X11 includes)

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -13,6 +13,11 @@
 
 #pragma warning(push, 0)
 #include <FL/fl_types.h>
+#ifndef _WIN32
+#include <FL/platform.H>
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#endif
 #pragma warning(pop)
 
 #ifdef _WIN32

--- a/src/utils.h
+++ b/src/utils.h
@@ -14,9 +14,9 @@
 #pragma warning(push, 0)
 #include <FL/fl_types.h>
 #ifndef _WIN32
-#include <FL/platform.H>
-#include <X11/Xlib.h>
-#include <X11/Xatom.h>
+#  ifdef FLTK_USE_X11
+#  include <FL/x11.H>
+#  endif
 #endif
 #pragma warning(pop)
 


### PR DESCRIPTION
### Problem

Building the Linux (X11) target against **FLTK 1.4.5** fails:

```
src/main-window.cpp: error: 'fl_display' was not declared in this scope
src/main-window.cpp: error: 'XA_CARDINAL' was not declared in this scope
src/main-window.h:  error: 'Pixmap' does not name a type
```

`main-window.{cpp,h}`, `modal-dialog.cpp` and `option-dialogs.cpp` use `fl_display`,
`fl_xid`, `Pixmap` and `XA_CARDINAL` under `#ifndef _WIN32`, but only `<X11/xpm.h>` is
included. The missing includes were introduced in
[ea112f0](https://github.com/Rangi42/tilemap-studio/commit/ea112f0486af1656379e64f0e3bd9a48ed74b16c)
("Save and restore maximized window state in Linux (Xlib)") in 2021 — they were masked by
FLTK ≤ 1.4.4, which leaked these symbols transitively. FLTK 1.4.5 cleaned up its platform headers and stopped
leaking them, so the omission now causes a hard build failure.

### Fix

Add the X11 / FLTK-platform includes to the shared `src/utils.h` (guarded `#ifndef _WIN32`),
so every translation unit that needs them gets them.

### Build environment

Ubuntu 26.04, GCC 15, FLTK 1.4.5 built X11-only (`FLTK_BACKEND_WAYLAND=0`). Found while
packaging Tilemap Studio for Foundry Linux.
